### PR TITLE
Remove service status check

### DIFF
--- a/Formula/steampipe.rb
+++ b/Formula/steampipe.rb
@@ -1,8 +1,8 @@
 class Steampipe < Formula
   desc "Use SQL to instantly query your cloud services"
   homepage "https://steampipe.io/"
-  url "https://github.com/turbot/steampipe/archive/refs/tags/v0.19.5.tar.gz"
-  sha256 "f01cf2a6b9d17a9bb571b754a50d00bbd44bf5073237c1ff3fb9fa61d5c9348e"
+  url "https://github.com/turbot/steampipe/archive/refs/tags/v0.20.2.tar.gz"
+  sha256 "2f714af79addc6d0f98e5bfff386ecd697d3f6e11078162e971414b217ac03ed"
   license "AGPL-3.0-only"
   head "https://github.com/turbot/steampipe.git", branch: "main"
 
@@ -30,12 +30,6 @@ class Steampipe < Formula
   end
 
   test do
-    output = shell_output(bin/"steampipe service status 2>&1")
-    if OS.mac?
-      assert_match "Error: could not create installation directory", output
-    else # Linux
-      assert_match "Steampipe service is not installed", output
-    end
     assert_match "Steampipe v#{version}", shell_output(bin/"steampipe --version")
   end
 end


### PR DESCRIPTION
Running `steampipe --version` is enough to verify that the steampipe binary is installed and available. Running `steampipe service status` is unnecessary.

This removes the need to tie the test to `Error` outputs which undergo continual improvements.

The output of `steampipe --version` has been frozen and will continue to remain in the same format for subsequent versions.

Plus, `steampipe --version` always exits with an `exit code` of `0`